### PR TITLE
Add custom_proc config to read raw input from deriv_root

### DIFF
--- a/mne_bids_pipeline/_config.py
+++ b/mne_bids_pipeline/_config.py
@@ -136,6 +136,48 @@ proc: str | None = None
 The BIDS `processing` entity.
 """
 
+custom_proc: str | None = None
+"""
+Read raw input data from `deriv_root` instead of `bids_root`. Use this when
+running custom preprocessing steps before MNE-BIDS-Pipeline.
+
+When set to a non-empty alphanumeric string (e.g. `"init"`), the pipeline's
+first read of "raw" data is redirected to:
+
+```
+<deriv_root>/sub-X/[ses-Y]/<datatype>/sub-X_..._proc-<custom_proc>_raw.fif
+```
+
+The recommended workflow is:
+
+1. Run `mne_bids_pipeline --steps=init` to create `deriv_root`.
+2. Run your custom preprocessing externally, writing FIFs into `deriv_root`
+   following the BIDS-derivatives naming convention with `processing=<custom_proc>`,
+   `suffix="raw"`, `extension=".fif"`.
+3. Run `mne_bids_pipeline --steps=preprocessing` (or another stage). The
+   pipeline will read the custom-preprocessed FIFs from `deriv_root` rather
+   than reading raw data from `bids_root`.
+
+Because `deriv_root` is not a complete BIDS dataset, the pipeline will load
+the FIFs directly with `mne.io.read_raw_fif` rather than `mne_bids.read_raw_bids`.
+This means bad-channel marks (`raw.info["bads"]`), channel types, and event
+annotations (`raw.annotations`) **must already be baked into the FIF**. The
+typical way to achieve this is to load the original data with
+`mne_bids.read_raw_bids`, apply your custom preprocessing, and save with
+`raw.save()` — that round-trip preserves all the relevant metadata.
+
+`bids_root` is still required (it is used for subject/session discovery,
+sidecar-based event counts in the report, FreeSurfer / forward-model paths,
+and as the fall-back location for empty-room data).
+
+Mutually exclusive with `proc`: setting both raises a `ConfigError`.
+
+???+ example "Example"
+    ```python
+    custom_proc = "init"  # read sub-01_..._proc-init_raw.fif from deriv_root
+    ```
+"""
+
 rec: str | None = None
 """
 The BIDS `recording` entity.

--- a/mne_bids_pipeline/_config_import.py
+++ b/mne_bids_pipeline/_config_import.py
@@ -276,6 +276,23 @@ def _check_config(config: SimpleNamespace, config_path: PathLike | None) -> None
 
     config.bids_root.resolve(strict=True)
 
+    if config.custom_proc is not None:
+        if config.proc is not None:
+            raise ConfigError(
+                "`proc` and `custom_proc` are mutually exclusive: `proc` selects "
+                "files in `bids_root`, while `custom_proc` selects custom-preprocessed "
+                "files in `deriv_root`. Got "
+                f"proc={config.proc!r}, custom_proc={config.custom_proc!r}."
+            )
+        if not isinstance(config.custom_proc, str) or not re.fullmatch(
+            r"[a-zA-Z0-9]+", config.custom_proc
+        ):
+            raise ConfigError(
+                "`custom_proc` must be a non-empty alphanumeric string (BIDS entity "
+                "values cannot contain underscores or hyphens). Got "
+                f"custom_proc={config.custom_proc!r}."
+            )
+
     if (
         config.use_maxwell_filter
         and len(set(config.ch_types).intersection(("meg", "grad", "mag"))) == 0

--- a/mne_bids_pipeline/_import_data.py
+++ b/mne_bids_pipeline/_import_data.py
@@ -277,11 +277,22 @@ def _load_data(cfg: SimpleNamespace, bids_path: BIDSPath) -> mne.io.BaseRaw:
     # - sets raw.annotations using the BIDS events.tsv
 
     subject = bids_path.subject
-    raw = read_raw_bids(
-        bids_path=bids_path,
-        extra_params=cfg.reader_extra_params or {},
-        verbose=cfg.read_raw_bids_verbose,
-    )
+    if (
+        getattr(cfg, "custom_proc", None) is not None
+        and bids_path.root == cfg.deriv_root
+    ):
+        # Custom-preprocessed FIF in deriv_root. deriv_root is not a complete
+        # BIDS dataset (no channels.tsv / events.tsv / *_meg.json next to the
+        # FIF), so read_raw_bids would fail. The FIF is expected to carry its
+        # own bads, channel types, and annotations (the typical way to produce
+        # such a FIF is read_raw_bids -> custom preprocessing -> raw.save()).
+        raw = mne.io.read_raw_fif(bids_path.fpath, **(cfg.reader_extra_params or {}))
+    else:
+        raw = read_raw_bids(
+            bids_path=bids_path,
+            extra_params=cfg.reader_extra_params or {},
+            verbose=cfg.read_raw_bids_verbose,
+        )
 
     _crop_data(cfg, raw=raw, subject=subject)
 
@@ -510,11 +521,21 @@ def import_er_data(
         return raw_er
 
     # Load reference run plus its auto-bads
-    raw_ref = read_raw_bids(
-        bids_path_ref_in,
-        extra_params=cfg.reader_extra_params or {},
-        verbose=cfg.read_raw_bids_verbose,
-    )
+    if (
+        getattr(cfg, "custom_proc", None) is not None
+        and bids_path_ref_in.root == cfg.deriv_root
+    ):
+        # See _load_data: when reading a custom-preprocessed FIF from deriv_root,
+        # bypass read_raw_bids because the BIDS sidecars don't exist there.
+        raw_ref = mne.io.read_raw_fif(
+            bids_path_ref_in.fpath, **(cfg.reader_extra_params or {})
+        )
+    else:
+        raw_ref = read_raw_bids(
+            bids_path_ref_in,
+            extra_params=cfg.reader_extra_params or {},
+            verbose=cfg.read_raw_bids_verbose,
+        )
     if bids_path_ref_bads_in is not None:
         bads = _read_bads_tsv(
             cfg=cfg,
@@ -599,6 +620,14 @@ def _get_bids_path_in(
         path_kwargs["suffix"] = "raw"
         path_kwargs["extension"] = ".fif"
         path_kwargs["processing"] = kind
+    elif getattr(cfg, "custom_proc", None) is not None:
+        # User has run their own preprocessing and written
+        # *_proc-<custom_proc>_raw.fif files into deriv_root. Read those
+        # instead of the BIDS raw files.
+        path_kwargs["root"] = cfg.deriv_root
+        path_kwargs["suffix"] = "raw"
+        path_kwargs["extension"] = ".fif"
+        path_kwargs["processing"] = cfg.custom_proc
     else:
         path_kwargs["root"] = cfg.bids_root
         path_kwargs["suffix"] = None
@@ -693,10 +722,34 @@ def _get_noise_path(
             task=get_task(config=cfg),
             kind=kind,
         )
-        raw_fname = _read_json(_empty_room_match_path(raw_fname, cfg))["fname"]
+        if getattr(cfg, "custom_proc", None) is not None:
+            # _02_find_empty_room.py writes the JSON keyed off the bids_root
+            # path of the experimental run; reset entities so we read from
+            # the same location.
+            json_run_path = raw_fname.copy().update(
+                root=cfg.bids_root,
+                processing=cfg.proc,
+                suffix=None,
+                extension=None,
+            )
+        else:
+            json_run_path = raw_fname
+        raw_fname = _read_json(_empty_room_match_path(json_run_path, cfg))["fname"]
         if raw_fname is None:
             return dict()
         raw_fname = get_bids_path_from_fname(raw_fname)
+        if getattr(cfg, "custom_proc", None) is not None:
+            # Auto-fallback: try a custom-preprocessed empty-room FIF in
+            # deriv_root first; fall back to the bids_root path if missing.
+            candidate = raw_fname.copy().update(
+                root=cfg.deriv_root,
+                processing=cfg.custom_proc,
+                suffix="raw",
+                extension=".fif",
+                check=False,
+            )
+            if candidate.fpath.exists():
+                raw_fname = candidate
     return _path_dict(
         cfg=cfg,
         bids_path_in=raw_fname,
@@ -844,6 +897,9 @@ def _import_data_kwargs(*, config: SimpleNamespace, subject: str) -> dict[str, A
         process_empty_room=config.process_empty_room,
         process_rest=config.process_rest,
         task_is_rest=config.task_is_rest,
+        # _get_bids_path_in, _load_data, _get_noise_path: read raw input from
+        # deriv_root (custom-preprocessed) instead of bids_root.
+        custom_proc=config.custom_proc,
         # _get_raw_paths, _get_noise_path
         use_maxwell_filter=config.use_maxwell_filter,
         mf_reference_run=get_mf_reference_run(config=config),

--- a/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
+++ b/mne_bids_pipeline/steps/preprocessing/_01_data_quality.py
@@ -209,7 +209,7 @@ def assess_data_quality(
         task=task,
     ) as report:
         # Original data
-        kind = "original" if not cfg.proc else cfg.proc
+        kind = getattr(cfg, "custom_proc", None) or cfg.proc or "original"
         msg = f"Adding {kind} raw data to report"
         logger.info(**gen_log_kwargs(message=msg))
         _add_raw(

--- a/mne_bids_pipeline/tests/test_documented.py
+++ b/mne_bids_pipeline/tests/test_documented.py
@@ -138,7 +138,7 @@ def test_config_options_used_in_steps() -> None:
     for func, count, nested in (
         # These "count" values can be updated when the helper functions change,
         # but it's nice to make sure we're getting what we expect otherwise
-        (_import_data_kwargs, 27, ()),
+        (_import_data_kwargs, 28, ()),
         (_limit_which_clean, 3, ()),
         (_restrict_analyze_channels, 3, ()),
         (_get_decoding_proc, 2, (_get_rank,)),

--- a/mne_bids_pipeline/tests/test_run.py
+++ b/mne_bids_pipeline/tests/test_run.py
@@ -284,6 +284,147 @@ allow_missing_sessions = {allow_missing_sessions}
             main()
 
 
+def test_custom_proc(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Test reading raw input from `deriv_root` via `custom_proc`.
+
+    Builds a tiny real EEG BIDS dataset, runs the pipeline `init` step to
+    create the derivatives folder, then writes a custom-preprocessed FIF into
+    `deriv_root` with `proc-init` naming. Finally, runs frequency filtering
+    with `custom_proc='init'` and verifies that the filtered output is
+    derived from the deriv_root file (not from `bids_root`).
+    """
+    import mne
+    import numpy as np
+    from mne_bids import BIDSPath as _BIDSPath
+    from mne_bids import write_raw_bids
+
+    bids_root = tmp_path / "bids"
+    deriv_root = tmp_path / "derivatives" / "mne-bids-pipeline"
+
+    # Build a tiny synthetic EEG raw with a couple of events.
+    sfreq = 200.0
+    n_chans = 4
+    n_samples = int(sfreq * 4)  # 4 s
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal((n_chans, n_samples)) * 1e-6
+    ch_names = [f"EEG{i:03d}" for i in range(n_chans)]
+    info = mne.create_info(ch_names=ch_names, sfreq=sfreq, ch_types="eeg")
+    raw = mne.io.RawArray(data, info)
+    raw.set_montage(
+        mne.channels.make_standard_montage("standard_1020"),
+        match_case=False,
+        on_missing="ignore",
+    )
+    # Two dummy events of two conditions.
+    onsets = np.array([0.5, 2.5])
+    raw.set_annotations(
+        mne.Annotations(
+            onset=onsets, duration=[0.0, 0.0], description=["cond_a", "cond_b"]
+        )
+    )
+
+    bp = _BIDSPath(
+        subject="01",
+        task="foo",
+        datatype="eeg",
+        root=bids_root,
+        suffix="eeg",
+        extension=".vhdr",
+    )
+    import warnings as _warnings
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("ignore")
+        write_raw_bids(
+            raw,
+            bp,
+            events=None,
+            format="BrainVision",
+            allow_preload=True,
+            overwrite=True,
+            verbose=False,
+        )
+
+    # Write the pipeline config.
+    config_text = f"""
+bids_root = "{bids_root}"
+deriv_root = "{deriv_root}"
+interactive = False
+subjects = ["01"]
+task = "foo"
+ch_types = ["eeg"]
+conditions = ["cond_a", "cond_b"]
+custom_proc = "init"
+process_empty_room = False
+process_rest = False
+l_freq = None
+h_freq = 40
+"""
+    config_path = tmp_path / "custom_proc_config.py"
+    config_path.write_text(config_text)
+
+    # Step 1: run init to create the derivatives folder.
+    monkeypatch.setenv("_MNE_BIDS_STUDY_TESTING", "true")
+    monkeypatch.setattr(
+        sys, "argv", ["mne_bids_pipeline", str(config_path), "--steps=init"]
+    )
+    with capsys.disabled():
+        print()
+        main()
+    assert (deriv_root / "dataset_description.json").exists()
+
+    # Step 2: emulate the user's external custom preprocessing by writing
+    # a *_proc-init_raw.fif into deriv_root. We just save the original raw
+    # we built above (it already has annotations baked in).
+    custom_path = (
+        deriv_root
+        / "sub-01"
+        / "eeg"
+        / "sub-01_task-foo_proc-init_raw.fif"
+    )
+    raw.save(custom_path, overwrite=True)
+    assert custom_path.exists()
+
+    # Step 3: run frequency filtering. With custom_proc='init', the pipeline
+    # must read from deriv_root (not bids_root). Run only the steps needed
+    # to exercise the redirection: data quality + frequency filtering.
+    # _01_data_quality is the first step that reads "orig" data, and it
+    # also writes a bads.tsv that _04 needs.
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "mne_bids_pipeline",
+            str(config_path),
+            "--steps=preprocessing/_01_data_quality,preprocessing/_04_frequency_filter",
+        ],
+    )
+    with capsys.disabled():
+        print()
+        main()
+
+    # Verify that the filtered output exists.
+    filt_path = (
+        deriv_root
+        / "sub-01"
+        / "eeg"
+        / "sub-01_task-foo_proc-filt_raw.fif"
+    )
+    assert filt_path.exists(), (
+        f"Expected filtered output {filt_path} but it does not exist. "
+        "Pipeline did not read from custom-preprocessed deriv_root file."
+    )
+    # Sanity: the filtered file should be smaller than 1 s of raw data
+    # (we only have 4 s of data).
+    raw_filt = mne.io.read_raw_fif(filt_path)
+    assert raw_filt.info["sfreq"] == sfreq
+    assert raw_filt.n_times == n_samples
+
+
 @pytest.mark.dataset_test
 def test_session_specific_mri(
     monkeypatch: pytest.MonkeyPatch,

--- a/mne_bids_pipeline/tests/test_validation.py
+++ b/mne_bids_pipeline/tests/test_validation.py
@@ -107,3 +107,22 @@ def test_validation(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     bad_text += "on_error = 'debug' if debug else 'raise'\n"
     config_path.write_text(bad_text)
     _import_config(config_path=config_path)  # this is okay
+
+    # custom_proc must not be combined with proc
+    bad_text = working_text + "proc = 'sss'\ncustom_proc = 'init'\n"
+    config_path.write_text(bad_text)
+    with pytest.raises(ConfigError, match=r"`proc` and `custom_proc` are mutually"):
+        _import_config(config_path=config_path)
+    # custom_proc must be a non-empty alphanumeric string
+    bad_text = working_text + "custom_proc = ''\n"
+    config_path.write_text(bad_text)
+    with pytest.raises(ConfigError, match=r"`custom_proc` must be a non-empty"):
+        _import_config(config_path=config_path)
+    bad_text = working_text + "custom_proc = 'has-hyphen'\n"
+    config_path.write_text(bad_text)
+    with pytest.raises(ConfigError, match=r"`custom_proc` must be a non-empty"):
+        _import_config(config_path=config_path)
+    # a well-formed custom_proc on its own is fine
+    bad_text = working_text + "custom_proc = 'init'\n"
+    config_path.write_text(bad_text)
+    _import_config(config_path=config_path)


### PR DESCRIPTION
Allows users to run their own preprocessing before MBP and have the pipeline pick up the resulting FIFs from `deriv_root` instead of reading from `bids_root`. The standard workflow is:

1. `mne_bids_pipeline --steps=init` to scaffold deriv_root.
2. Run external preprocessing scripts that write `*_proc-<custom_proc>_raw.fif` files into deriv_root.
3. `mne_bids_pipeline --steps=preprocessing` to continue from those FIFs.

When `custom_proc` is set, `_get_bids_path_in()` redirects "orig" lookups to deriv_root and `_load_data()` bypasses `read_raw_bids` in favor of `mne.io.read_raw_fif` (since deriv_root has no BIDS sidecars). Empty-room data falls back: deriv_root first, then bids_root.

`proc` and `custom_proc` are mutually exclusive.

https://claude.ai/code/session_0183FqYanQy7rpgxa97RAgYz

### Before merging …

- [ ] Changelog has been updated (`docs/source/dev.md.inc`)
